### PR TITLE
Fix Python version metadata (3.7+ → 3.8+) and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.12", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build and install extension
+        working-directory: leximini
+        run: maturin develop --release
+
+      - name: Verify import
+        run: python -c "import leximini; print('leximini imported successfully')"
+
+      - name: Run tests
+        run: |
+          pip install pytest
+          pytest test_bpe.py test_tokenizer.py -v

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ assert decoded_text == text_to_encode
 ## 🛠️ Building from Source
 
 If you want to modify the source code or build the extension yourself locally, you will need:
-- **Python 3.7+**
+- **Python 3.8+**
 - **Rust and Cargo**: Install from [rustup.rs](https://rustup.rs/)
 
 ### Instructions

--- a/leximini/README.md
+++ b/leximini/README.md
@@ -5,7 +5,7 @@ A minimal byte-pair encoding (BPE) tokenizer implementation in Rust, with Python
 ## Requirements
 
 To install and build this package from source, you will need:
-- **Python 3.7+**
+- **Python 3.8+**
 - **Rust and Cargo**: Install from [rustup.rs](https://rustup.rs/)
 
 ## Installation

--- a/leximini/pyproject.toml
+++ b/leximini/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "leximini"
 version = "0.1.0"
 description = "LexiMini: A Rust-based BPE tokenizer for Python"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
- Update requires-python to >=3.8 in pyproject.toml to match abi3-py38
- Update Python version references in README.md and leximini/README.md
- Add GitHub Actions CI workflow testing Python 3.8, 3.12, and 3.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration workflow for automated testing across Python versions 3.8, 3.12, and 3.14.
  * Updated minimum Python version requirement from 3.7+ to 3.8+.

* **Documentation**
  * Updated README documentation to reflect Python 3.8+ minimum requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->